### PR TITLE
Reworked 'shared_get'

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,17 +61,9 @@ of live ArcShift instances. Payload values only stay in memory if they are activ
 ArcShift instance. This means arcshift no longer requires that all instances are periodically reloaded
 in order to avoid excessive memory consumption.
 
-Worst case memory consumption is now:
-
-* Number of unique refs multiplied by `size_of<T>`
-
-plus
-
-* Sum of memory owned by strongly referenced T 
-
-Shared references to ArcShift can no longer provide the most up-to-date value. You should make sure to 
-always have owned (mutable) ArcShift objects. The reason for this change is that this is what allows
-intermediary values from being dropped quickly.
+Shared references to ArcShift, now have a larger performance penalty if writes have occurred.
+(You should make sure to always have owned (mutable) ArcShift objects). The reason for this change 
+is that this is what allows intermediary values from being dropped quickly.
 
 The API for RCU has been cleaned up. RCU is now always lock-free, and there is no fallible variant.
 
@@ -90,7 +82,7 @@ rarely updated, paying mutex overhead on each access is undesirable.
 
 ### ArcSwap
 
-ArcShift to some extent solves the same problem as ArcSwap (see: <https://docs.rs/arc-swap/> ).
+ArcShift (to some extent) solves the same problem as ArcSwap (see: <https://docs.rs/arc-swap/> ).
 
 ArcSwap is a container for `Arc<T>`-objects, which allows swapping out the contained
 Arc-object without requiring a &mut-reference.
@@ -106,7 +98,7 @@ The requirements for ArcShift are:
  * Regular shared read access should be approximately as fast as for `Arc<T>`, as long as 
    writes have not occurred.
  * Writes can be expensive (but of course not slower than necessary)
- * It is okay if reads become slightly slower after a write has occurred.
+ * It is okay if reads become slower after a write has occurred.
  * The implementation should be lock free (so we never have to suspend a thread)
  * The API must be 100% safe and sound.
  * When values are updated, previous values should be dropped as soon as possible. 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ fn main () {
 
 For docs, see <https://docs.rs/arcshift/> .
 
+# Upgrading from 0.2.6
+
+0.2.7 reworks how `shared_get` works. Previously, this method would simply return stale values, in case the
+ArcShift instance was stale. With 0.2.7, stale values will be detected, the arcshift will be cloned and reloaded,
+and a guard will be returned with a possibly reloaded clone.
+
+This is still pretty fast in the case that the self instance is _not_ stale. However, there is a severe
+performance penalty for stale values. Being slow but correct is probably the better default. The method
+`non_reloading_get` can be used to get very quick access, while possibly stale.
+
 # Upgrading from 0.1.x
 
 Release 0.2.0 is a breaking change. The major advantage of 0.2.0 is that it has bounded memory consumption at

--- a/arcshift/examples/basic.rs
+++ b/arcshift/examples/basic.rs
@@ -1,0 +1,21 @@
+use arcshift::ArcShift;
+use std::thread;
+
+fn main() {
+    let mut arc = ArcShift::new("Hello".to_string());
+    let mut arc2 = arc.clone();
+
+    let j1 = thread::spawn(move || {
+        println!("Value in thread 1: '{}'", arc.get()); //Prints 'Hello'
+        arc.update("New value".to_string());
+        println!("Updated value in thread 1: '{}'", arc.get()); //Prints 'New value'
+    });
+
+    let j2 = thread::spawn(move || {
+        // Prints either 'Hello' or 'New value', depending on scheduling:
+        println!("Value in thread 2: '{}'", arc2.get());
+    });
+
+    j1.join().unwrap();
+    j2.join().unwrap();
+}

--- a/arcshift/src/cell.rs
+++ b/arcshift/src/cell.rs
@@ -61,7 +61,7 @@ impl<T: 'static + ?Sized> Deref for ArcShiftCellHandle<'_, T> {
             // Actual mutable references to the 'inner' never live long enough
             // to be visible by the user of this module.
             let inner: &ArcShift<T> = unsafe { &*self.cell.inner.get() };
-            inner.shared_get()
+            inner.shared_non_reloading_get()
         }
     }
 }
@@ -155,7 +155,7 @@ impl<T: 'static + ?Sized> ArcShiftCell<T> {
         } else {
             // SAFETY:
             // Getting the inner value is safe, no other thread can be accessing it now
-            unsafe { &*self.inner.get() }.shared_get()
+            unsafe { &*self.inner.get() }.shared_non_reloading_get()
         };
         f(val);
         self.recursion.set(self.recursion.get() - 1);

--- a/arcshift/src/lib.rs
+++ b/arcshift/src/lib.rs
@@ -2906,7 +2906,7 @@ pub enum SharedGetGuard<'a, T: ?Sized> {
     Cloned(ArcShift<T>),
 }
 
-impl<'a, T> core::ops::Deref for SharedGetGuard<'a, T> {
+impl<T> core::ops::Deref for SharedGetGuard<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {

--- a/arcshift/src/tests/custom_fuzz.rs
+++ b/arcshift/src/tests/custom_fuzz.rs
@@ -95,7 +95,7 @@ fn run_multi_fuzz<T: Clone + Hash + Eq + 'static + Debug + Send + Sync>(
                     }
                     FuzzerCommand::SharedReadArc { .. } => {
                         if let Some(curval) = curval.as_mut() {
-                            let actual = curval.shared_get();
+                            let actual = curval.shared_non_reloading_get();
                             if !thread_all_possible.contains(actual) {
                                 panic!("Unexpected value in thread {}, got {:?} which is not in {:?}", threadnr, actual, thread_all_possible);
                             }
@@ -213,7 +213,7 @@ fn run_fuzz<T: Clone + Hash + Eq + 'static + Debug + Send + Sync>(
             }
             FuzzerCommand::SharedReadArc { arc } => {
                 if let Some(actual) = &mut arcs[arc as usize] {
-                    let actual_val = actual.shared_get();
+                    let actual_val = actual.shared_non_reloading_get();
 
                     std::hint::black_box(actual_val);
                 }

--- a/arcshift/src/tests/race_detector.rs
+++ b/arcshift/src/tests/race_detector.rs
@@ -560,7 +560,7 @@ fn generic_3threading_b_all_impl(skip1: usize, skip2: usize, skip3: usize, repro
         },
         |_owner, shift, _thread| {
             debug_println!("====> shift.shared_get()");
-            std::hint::black_box(shift.shared_get());
+            std::hint::black_box(shift.shared_non_reloading_get());
             Some(shift)
         },
         |_owner, mut shift, _thread| {
@@ -632,7 +632,7 @@ fn generic_3threading_a_all_impl(skip0: usize, skip1: usize, skip2: usize) {
         },
         |_owner, shift, _thread| {
             debug_println!("====> shift.shared_get()");
-            std::hint::black_box(shift.shared_get());
+            std::hint::black_box(shift.shared_non_reloading_get());
             Some(shift)
         },
         |_owner, mut shift, _thread| {

--- a/arcshift_bench/benches/my_benchmark.rs
+++ b/arcshift_bench/benches/my_benchmark.rs
@@ -72,6 +72,21 @@ fn arcshift_shared_bench(c: &mut Criterion) {
     let ac = ArcShift::new(42u32);
     c.bench_function("arcshift_shared_get", |b| b.iter(|| *ac.shared_get()));
 }
+
+fn arcshift_shared_stale_bench(c: &mut Criterion) {
+    let mut ac_base = ArcShift::new(42u32);
+    let ac = ac_base.clone();
+    ac_base.update(43);
+    c.bench_function("arcshift_shared_stale_get", |b| b.iter(|| *ac.shared_get()));
+}
+
+fn arcshift_shared_non_reloading_bench(c: &mut Criterion) {
+    let ac = ArcShift::new(42u32);
+    c.bench_function("arcshift_shared_non_reloading_get", |b| {
+        b.iter(|| *ac.shared_non_reloading_get())
+    });
+}
+
 fn arcswap_bench(c: &mut Criterion) {
     let ac = ArcSwap::from_pointee(42);
     c.bench_function("arc_swap", |b| {
@@ -103,6 +118,8 @@ fn arcswap_update(c: &mut Criterion) {
 criterion_group!(
     benches,
     arcshift_shared_bench,
+    arcshift_shared_stale_bench,
+    arcshift_shared_non_reloading_bench,
     std_arc_bench,
     rwlock_write_bench,
     arcshift_bench,


### PR DESCRIPTION
'shared_get' now always gives the most up-to-date value.

However, in the case that an update is available, there is a severe performance penalty (think several 10s of nanoseconds).