### PR TITLE
Downgrade criterion for 1.75 compat

### DIFF
--- a/arcshift_bench/Cargo.toml
+++ b/arcshift_bench/Cargo.toml
@@ -7,7 +7,12 @@ edition = "2021"
 
 
 [dev-dependencies]
-criterion = "0.3"
+# Expliclitly choose older versions, since newer versions don't support rust 1.75.
+# Running these old versions in test should be fine. This code does not end up
+# in the final library.
+criterion = "0.3.6"
+rayon-core = "=1.11.0"
+half = "=2.4"
 
 [dependencies]
 arcshift = {path = "../arcshift"}


### PR DESCRIPTION
Downgrade criterion to 0.3.6, and some of its dependencies as well, in the benchmark.

This makes it possible to keep supporting rust 1.75.

There are no significant downsides, this check does not affect downstream crates. The downgrade is only for the bench-crate, which is not exported to crates.io.