### PR TITLE
Make Debug impl for ArcShift be idiomatic rust

### DIFF
--- a/arcshift/CHANGELOG.md
+++ b/arcshift/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.3
+
+Fix Debug impl of ArcShift, so that it honors "{:#?}" format strings.
+
 ## 0.4.2
 
 Support rust 1.75 (0.4.1 regressed to require newer rust).

--- a/arcshift/src/lib.rs
+++ b/arcshift/src/lib.rs
@@ -413,7 +413,7 @@ where
     T: Debug,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "ArcShift({:?})", self.shared_non_reloading_get())
+        f.debug_tuple("ArcShift").field(&self.shared_non_reloading_get()).finish()
     }
 }
 
@@ -428,7 +428,7 @@ where
     T: Debug,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "ArcShiftWeak(..)")
+        f.debug_tuple("ArcShiftWeak").finish_non_exhaustive()
     }
 }
 

--- a/arcshift/src/lib.rs
+++ b/arcshift/src/lib.rs
@@ -413,7 +413,9 @@ where
     T: Debug,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("ArcShift").field(&self.shared_non_reloading_get()).finish()
+        f.debug_tuple("ArcShift")
+            .field(&self.shared_non_reloading_get())
+            .finish()
     }
 }
 

--- a/arcshift/src/lib.rs
+++ b/arcshift/src/lib.rs
@@ -428,7 +428,7 @@ where
     T: Debug,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("ArcShiftWeak").finish_non_exhaustive()
+        write!(f, "ArcShiftWeak(..)")
     }
 }
 

--- a/arcshift/src/tests.rs
+++ b/arcshift/src/tests.rs
@@ -17,7 +17,7 @@ use std::hint::black_box;
 use std::mem::MaybeUninit;
 use std::string::ToString;
 use std::sync::atomic::AtomicUsize;
-use std::thread;
+use std::{format, thread};
 use std::time::Duration;
 use std::vec;
 
@@ -2654,6 +2654,26 @@ fn simple_threading_try_into_inner3() {
         debug_println!("--> Main dropping");
         assert_eq!(r1 as u32 + r2 as u32 + r3 as u32, 1);
     });
+}
+
+#[test]
+fn check_debug_impls() {
+    #[derive(Debug)]
+    struct Sample {
+        x: u32,
+        y: bool
+    }
+
+    let x = ArcShift::new(Sample {
+        x: 42,
+        y: false
+    });
+    let weak = ArcShift::downgrade(&x);
+
+    assert_eq!(format!("{:?}", x), "ArcShift(Sample { x: 42, y: false })");
+    assert_eq!(format!("{:?}", weak), "ArcShiftWeak(..)");
+    assert_eq!(format!("{:#?}", x), "ArcShift(\n    Sample {\n        x: 42,\n        y: false,\n    },\n)");
+    assert_eq!(format!("{:#?}", weak), "ArcShiftWeak(..)");
 }
 
 /*

--- a/arcshift/src/tests.rs
+++ b/arcshift/src/tests.rs
@@ -17,9 +17,9 @@ use std::hint::black_box;
 use std::mem::MaybeUninit;
 use std::string::ToString;
 use std::sync::atomic::AtomicUsize;
-use std::{format, thread};
 use std::time::Duration;
 use std::vec;
+use std::{format, thread};
 
 mod custom_fuzz;
 pub(crate) mod leak_detection;
@@ -2661,18 +2661,18 @@ fn check_debug_impls() {
     #[derive(Debug)]
     struct Sample {
         x: u32,
-        y: bool
+        y: bool,
     }
 
-    let x = ArcShift::new(Sample {
-        x: 42,
-        y: false
-    });
+    let x = ArcShift::new(Sample { x: 42, y: false });
     let weak = ArcShift::downgrade(&x);
 
     assert_eq!(format!("{:?}", x), "ArcShift(Sample { x: 42, y: false })");
     assert_eq!(format!("{:?}", weak), "ArcShiftWeak(..)");
-    assert_eq!(format!("{:#?}", x), "ArcShift(\n    Sample {\n        x: 42,\n        y: false,\n    },\n)");
+    assert_eq!(
+        format!("{:#?}", x),
+        "ArcShift(\n    Sample {\n        x: 42,\n        y: false,\n    },\n)"
+    );
     assert_eq!(format!("{:#?}", weak), "ArcShiftWeak(..)");
 }
 


### PR DESCRIPTION
Use idiomatic debug printing

This supports "{:#?}" formats